### PR TITLE
A bit less memory consumption for IndexedConv

### DIFF
--- a/examples/benchmark_indexed_conv.py
+++ b/examples/benchmark_indexed_conv.py
@@ -237,7 +237,6 @@ if __name__ == '__main__':
         ram_f = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
         logger.info('Memory allocated : {} in MB'.format(ram_f))
         nn_hexa_net_ram.append(ram_f - ram_b)
-        logger.info('Time for indexed widenet {}'.format(t))
         logger.info('Time for masked nn widenet {}'.format(t))
         del nn_net
         del out

--- a/examples/benchmark_indexed_conv.py
+++ b/examples/benchmark_indexed_conv.py
@@ -101,7 +101,8 @@ if __name__ == '__main__':
 
         cv_nn.to(device)
         cv_square.to(device)
-        ram_b = torch.cuda.memory_allocated() / 1024 / 1024
+        ram_b = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_b))
         start_square = time.time()
         for _ in range(iterations):
             cv_square.zero_grad()
@@ -110,13 +111,17 @@ if __name__ == '__main__':
             loss_square.backward()
         t = (time.time() - start_square) / iterations
         indexed_conv.append(t)
-        indexed_conv_ram.append(torch.cuda.memory_allocated() / 1024 / 1024 - ram_b)
+        ram_f = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_f))
+        indexed_conv_ram.append(ram_f - ram_b)
         logger.info('Time for 1 indexed conv + backward : {}'.format(t))
         del cv_square
         del convoluted_square
+        del loss_square
         torch.cuda.empty_cache()
 
-        ram_b = torch.cuda.memory_allocated() / 1024 / 1024
+        ram_b = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_b))
         start_nn = time.time()
         for _ in range(iterations):
             cv_nn.zero_grad()
@@ -125,10 +130,13 @@ if __name__ == '__main__':
             loss_nn.backward()
         t = (time.time() - start_nn) / iterations
         nn_conv.append(t)
-        nn_conv_ram.append(torch.cuda.memory_allocated() / 1024 / 1024 - ram_b)
+        ram_f = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_f))
+        nn_conv_ram.append(ram_f - ram_b)
         logger.info('Time for 1 nn conv + backward : {}'.format(t))
         del cv_nn
         del convoluted_nn
+        del loss_nn
         torch.cuda.empty_cache()
 
         logger.info('Compare indexed conv and nn.Conv2d on square images with WideNet')
@@ -137,7 +145,8 @@ if __name__ == '__main__':
         indexed_net = WideNetIndexConvIndexPool(index_matrix_square.float(), 'Square', 30).to(device)
         nn_net = WideNet(30).to(device)
 
-        ram_b = torch.cuda.memory_allocated() / 1024 / 1024
+        ram_b = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_b))
         start_indexed = time.time()
         for _ in range(iterations):
             out = indexed_net(dummy_data.view(batch_size, c_in, -1))
@@ -145,13 +154,17 @@ if __name__ == '__main__':
             loss.backward()
         t = (time.time() - start_indexed) / iterations
         indexed_square_net.append(t)
-        indexed_square_net_ram.append(torch.cuda.memory_allocated() / 1024 / 1024 - ram_b)
+        ram_f = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_f))
+        indexed_square_net_ram.append(ram_f - ram_b)
         logger.info('Time for indexed widenet {}'.format(t))
         del indexed_net
         del out
+        del loss
         torch.cuda.empty_cache()
 
-        ram_b = torch.cuda.memory_allocated() / 1024 / 1024
+        ram_b = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_b))
         start_nn = time.time()
         for _ in range(iterations):
             out = nn_net(dummy_data)
@@ -159,10 +172,13 @@ if __name__ == '__main__':
             loss.backward()
         t = (time.time() - start_nn) / iterations
         nn_square_net.append(t)
-        nn_square_net_ram.append(torch.cuda.memory_allocated() / 1024 / 1024 - ram_b)
+        ram_f = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_f))
+        nn_square_net_ram.append(ram_f - ram_b)
         logger.info('Time for nn widenet {}'.format(t))
         del nn_net
         del out
+        del loss
         torch.cuda.empty_cache()
 
         logger.info('Compare indexed conv and nn.Conv2d on hexagonal images with WideNet')
@@ -191,7 +207,8 @@ if __name__ == '__main__':
         indexed_net = WideNetIndexConvIndexPool(index_matrix, 'Hex', 30).to(device)
         nn_net = WideNetMasked(30).to(device)
 
-        ram_b = torch.cuda.memory_allocated() / 1024 / 1024
+        ram_b = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_b))
         start_indexed = time.time()
         for d in hex_loader:
             out = indexed_net(d[0].to(device))
@@ -199,13 +216,17 @@ if __name__ == '__main__':
             loss.backward()
         t = (time.time() - start_indexed) / len(hex_loader)
         indexed_hexa_net.append(t)
-        indexed_hexa_net_ram.append(torch.cuda.memory_allocated() / 1024 / 1024 - ram_b)
+        ram_f = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_f))
+        indexed_hexa_net_ram.append(ram_f - ram_b)
         logger.info('Time for indexed widenet {}'.format(t))
         del indexed_net
         del out
+        del loss
         torch.cuda.empty_cache()
 
-        ram_b = torch.cuda.memory_allocated() / 1024 / 1024
+        ram_b = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_b))
         start_nn = time.time()
         for d in sh_loader:
             out = nn_net(d[0].to(device))
@@ -213,10 +234,14 @@ if __name__ == '__main__':
             loss.backward()
         t = (time.time() - start_nn) / len(sh_loader)
         nn_hexa_net.append(t)
-        nn_hexa_net_ram.append(torch.cuda.memory_allocated() / 1024 / 1024 - ram_b)
+        ram_f = (torch.cuda.memory_allocated() + torch.cuda.memory_cached()) / 1024 / 1024
+        logger.info('Memory allocated : {} in MB'.format(ram_f))
+        nn_hexa_net_ram.append(ram_f - ram_b)
+        logger.info('Time for indexed widenet {}'.format(t))
         logger.info('Time for masked nn widenet {}'.format(t))
         del nn_net
         del out
+        del loss
         torch.cuda.empty_cache()
 
     dataf = pd.DataFrame()

--- a/indexedconv/engine/indexed.py
+++ b/indexedconv/engine/indexed.py
@@ -31,14 +31,13 @@ class IndexedMaxPool2d(nn.Module):
         self.logger = logging.getLogger(__name__ + '.IndexedMaxPool2d')
         self.indices = indices
         self.indices, self.mask = utils.prepare_mask(self.indices)
+        self.register_buffer('indices_', self.indices)
+        self.register_buffer('mask_', self.mask)
 
     def forward(self, input_images):
         self.logger.debug('Max pool image')
 
-        self.indices = self.indices.to(input_images.device)
-        self.mask = self.mask.to(input_images.device)
-
-        col = input_images[..., self.indices] * self.mask
+        col = input_images[..., self.indices_] * self.mask_
 
         out, _ = torch.max(col, 2)
 
@@ -64,14 +63,13 @@ class IndexedAveragePool2d(nn.Module):
         self.logger = logging.getLogger(__name__ + '.IndexedAveragePool2d')
         self.indices = indices
         self.indices, self.mask = utils.prepare_mask(self.indices)
+        self.register_buffer('indices_', self.indices)
+        self.register_buffer('mask_', self.mask)
 
     def forward(self, input_images):
         self.logger.debug('Average pool image')
 
-        self.indices = self.indices.to(input_images.device)
-        self.mask = self.mask.to(input_images.device)
-
-        col = input_images[..., self.indices] * self.mask
+        col = input_images[..., self.indices_] * self.mask_
 
         out = torch.mean(col, 2)
 
@@ -170,12 +168,9 @@ class IndexedConv(nn.Module):
         col = input[..., self.indices_] * self.mask_
         # col is of shape (N, C_in, K, Wo)
         col = col.view(nbatch, -1, self.output_width)
-        # weight_col = self.weight.view(self.out_channels, -1)
-        # out = torch.matmul(weight_col, col)
         out = torch.bmm(self.weight.view(self.out_channels, -1).expand(nbatch, -1, -1), col)
         if self.bias is not None:
             out = out + self.bias.unsqueeze(1)
-        out = out.view(nbatch, self.out_channels, -1)
 
         return out
 

--- a/indexedconv/engine/indexed.py
+++ b/indexedconv/engine/indexed.py
@@ -133,7 +133,7 @@ class IndexedConv(nn.Module):
         super(IndexedConv, self).__init__()
         self.logger = logging.getLogger(__name__ + '.IndexedConv')
 
-        print('!!! bmm + no_grad version !!!')
+        self.logger.info('!!! bmm + no_grad version !!!')
         groups = 1
 
         kernel_size = indices.shape[0]

--- a/indexedconv/engine/indexed.py
+++ b/indexedconv/engine/indexed.py
@@ -133,7 +133,8 @@ class IndexedConv(nn.Module):
         super(IndexedConv, self).__init__()
         self.logger = logging.getLogger(__name__ + '.IndexedConv')
 
-        self.logger.info('!!! bmm + no_grad version !!!')
+        print('!!! bmm !!!')
+
         groups = 1
 
         kernel_size = indices.shape[0]
@@ -166,10 +167,9 @@ class IndexedConv(nn.Module):
 
     def forward(self, input):
         nbatch = input.shape[0]
-        with torch.no_grad():
-            col = input[..., self.indices_] * self.mask_
-            # col is of shape (N, C_in, K, Wo)
-            col = col.view(nbatch, -1, self.output_width)
+        col = input[..., self.indices_] * self.mask_
+        # col is of shape (N, C_in, K, Wo)
+        col = col.view(nbatch, -1, self.output_width)
         out = torch.bmm(self.weight.view(self.out_channels, -1).expand(nbatch, -1, -1), col)
         if self.bias is not None:
             out = out + self.bias.unsqueeze(1)

--- a/indexedconv/engine/indexed.py
+++ b/indexedconv/engine/indexed.py
@@ -170,9 +170,9 @@ class IndexedConv(nn.Module):
         col = input[..., self.indices_] * self.mask_
         # col is of shape (N, C_in, K, Wo)
         col = col.view(nbatch, -1, self.output_width)
-        weight_col = self.weight.view(self.out_channels, -1)
-        out = torch.matmul(weight_col, col)
-        # out = torch.bmm(self.weight.view(self.out_channels, -1).expand(nbatch, -1, -1), col)
+        # weight_col = self.weight.view(self.out_channels, -1)
+        # out = torch.matmul(weight_col, col)
+        out = torch.bmm(self.weight.view(self.out_channels, -1).expand(nbatch, -1, -1), col)
         if self.bias is not None:
             out = out + self.bias.unsqueeze(1)
         out = out.view(nbatch, self.out_channels, -1)

--- a/indexedconv/engine/indexed.py
+++ b/indexedconv/engine/indexed.py
@@ -170,7 +170,9 @@ class IndexedConv(nn.Module):
         col = input[..., self.indices_] * self.mask_
         # col is of shape (N, C_in, K, Wo)
         col = col.view(nbatch, -1, self.output_width)
-        out = torch.bmm(self.weight.view(self.out_channels, -1).expand(nbatch, -1, -1), col)
+        weight_col = self.weight.view(self.out_channels, -1)
+        out = torch.matmul(weight_col, col)
+        # out = torch.bmm(self.weight.view(self.out_channels, -1).expand(nbatch, -1, -1), col)
         if self.bias is not None:
             out = out + self.bias.unsqueeze(1)
         out = out.view(nbatch, self.out_channels, -1)


### PR DESCRIPTION
In this pr, we explicitly expand the weight to the batch size and apply bmm instead of using matmul in the forward function of IndexedConv. This uses a bit less memory. We also register as buffer the indices and the mask of convolution and pooling modules to move them to the chosen device at instantiation time instead of during the forward pass.